### PR TITLE
Treat database, role, schema, and warehouse names case-sensitively

### DIFF
--- a/django_snowflake/base.py
+++ b/django_snowflake/base.py
@@ -94,7 +94,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         conn_params = {}
 
         if settings_dict['NAME']:
-            conn_params['database'] = settings_dict['NAME']
+            conn_params['database'] = self.ops.quote_name(settings_dict['NAME'])
 
         if settings_dict['USER']:
             conn_params['user'] = settings_dict['USER']
@@ -112,15 +112,15 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             raise ImproperlyConfigured(self.settings_is_missing % 'ACCOUNT')
 
         if settings_dict.get('WAREHOUSE'):
-            conn_params['warehouse'] = settings_dict['WAREHOUSE']
+            conn_params['warehouse'] = self.ops.quote_name(settings_dict['WAREHOUSE'])
         else:
             raise ImproperlyConfigured(self.settings_is_missing % 'WAREHOUSE')
 
         if settings_dict.get('ROLE'):
-            conn_params['role'] = settings_dict['ROLE']
+            conn_params['role'] = self.ops.quote_name(settings_dict['ROLE'])
 
         if settings_dict.get('SCHEMA'):
-            conn_params['schema'] = settings_dict['SCHEMA']
+            conn_params['schema'] = self.ops.quote_name(settings_dict['SCHEMA'])
         else:
             raise ImproperlyConfigured(self.settings_is_missing % 'SCHEMA')
 


### PR DESCRIPTION
In particular, Django creates test databases prefixed with "test_", and
if the name isn't quoted, subsequent connections will instead use
 "TEST_".