### PR TITLE
Update to Django 4.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'timgraham/django'
-          ref: 'snowflake-4.0.x'
+          ref: 'snowflake-4.1.x'
           path: 'django_repo'
       - name: Install system packages for Django's Python test dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## 4.0 alpha 1 - 2023-02-17
+## 4.1 alpha 1 - 2023-02-20
 
-Initial release for Django 4.0.x.
+Initial release for Django 4.1.x.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ## Install and usage
 
 Use the version of django-snowflake that corresponds to your version of
-Django. For example, to get the latest compatible release for Django 4.0.x:
+Django. For example, to get the latest compatible release for Django 4.1.x:
 
-`pip install django-snowflake==4.0.*`
+`pip install django-snowflake==4.1.*`
 
 The minor release number of Django doesn't correspond to the minor release
 number of django-snowflake. Use the latest minor release of each.

--- a/django_snowflake/__init__.py
+++ b/django_snowflake/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '4.0a1'
+__version__ = '4.1a1'
 
 # Check Django compatibility before other imports which may fail if the
 # wrong version of Django is installed.

--- a/django_snowflake/features.py
+++ b/django_snowflake/features.py
@@ -11,7 +11,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     enforces_foreign_key_constraints = False
     # This feature is specific to the Django fork used for testing.
     enforces_unique_constraints = False
-    has_case_insensitive_like = False
+    allows_multiple_constraints_on_same_fields = False
     has_json_object_function = False
     indexes_foreign_keys = False
     nulls_order_largest = True
@@ -67,6 +67,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # DatabaseOperations.format_for_duration_arithmetic() INTERVAL syntax
         # doesn't accept column names.
         'annotations.tests.NonAggregateAnnotationTestCase.test_mixed_type_annotation_date_interval',
+        'expressions.tests.FTimeDeltaTests.test_datetime_and_duration_field_addition_with_annotate_and_no_output_field',  # noqa
+        'expressions.tests.FTimeDeltaTests.test_datetime_and_durationfield_addition_with_filter',
         'expressions.tests.FTimeDeltaTests.test_duration_with_datetime',
         'expressions.tests.FTimeDeltaTests.test_durationfield_add',
         'expressions.tests.FTimeDeltaTests.test_durationfield_multiply_divide',
@@ -92,6 +94,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         'Snowflake does not enforce UNIQUE constraints.': {
             'model_fields.test_filefield.FileFieldTests.test_unique_when_same_filename',
             'one_to_one.tests.OneToOneTests.test_multiple_o2o',
+            'queries.test_bulk_update.BulkUpdateTests.test_database_routing_batch_atomicity',
         },
         'Snowflake does not support indexes.': {
             'introspection.tests.IntrospectionTests.test_get_constraints_index_types',
@@ -99,6 +102,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             'migrations.test_operations.OperationTests.test_alter_field_with_index',
             'migrations.test_operations.OperationTests.test_alter_index_together',
             'migrations.test_operations.OperationTests.test_remove_index',
+            'migrations.test_operations.OperationTests.test_rename_index',
+            'migrations.test_operations.OperationTests.test_rename_index_unnamed_index',
             'schema.tests.SchemaTests.test_add_remove_index',
             'schema.tests.SchemaTests.test_alter_field_add_index_to_integerfield',
             'schema.tests.SchemaTests.test_create_index_together',
@@ -117,8 +122,10 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             'model_fields.test_integerfield.PositiveIntegerFieldTests.test_negative_values',
         },
         'Snowflake: Unsupported subquery type cannot be evaluated.': {
+            'aggregation.test_filter_argument.FilteredAggregateTests.test_filtered_aggregate_on_exists',
             'aggregation.test_filter_argument.FilteredAggregateTests.test_filtered_aggregate_ref_multiple_subquery_annotation',  # noqa
             'aggregation.test_filter_argument.FilteredAggregateTests.test_filtered_aggregate_ref_subquery_annotation',
+            'aggregation.tests.AggregateTestCase.test_aggregation_exists_multivalued_outeref',
             'aggregation.tests.AggregateTestCase.test_aggregation_subquery_annotation',
             'aggregation.tests.AggregateTestCase.test_aggregation_subquery_annotation_values',
             'aggregation.tests.AggregateTestCase.test_aggregation_subquery_annotation_values_collision',
@@ -152,6 +159,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             'expressions.tests.BasicExpressionsTests.test_subquery_in_filter',
             'expressions.tests.FTimeDeltaTests.test_date_subquery_subtraction',
             'expressions.tests.FTimeDeltaTests.test_datetime_subquery_subtraction',
+            'queries.test_qs_combinators.QuerySetSetOperationTests.test_union_in_subquery',
+            'queries.test_qs_combinators.QuerySetSetOperationTests.test_union_in_subquery_related_outerref',
             'queries.test_qs_combinators.QuerySetSetOperationTests.test_union_with_values_list_on_annotated_and_unannotated',  # noqa
             'queries.tests.ExcludeTest17600.test_exclude_plain',
             'queries.tests.ExcludeTest17600.test_exclude_plain_distinct',
@@ -176,6 +185,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             'queries.tests.Queries1Tests.test_tickets_5324_6704',
             'queries.tests.Queries4Tests.test_ticket24525',
             'queries.tests.Queries6Tests.test_tickets_8921_9188',
+            'queries.tests.Queries6Tests.test_xor_subquery',
             'queries.tests.TestTicket24605.test_ticket_24605',
             'queries.tests.Ticket20788Tests.test_ticket_20788',
             'queries.tests.Ticket22429Tests.test_ticket_22429',
@@ -195,9 +205,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         'Snowflake does not support nested transactions.': {
             'model_fields.test_booleanfield.BooleanFieldTests.test_null_default',
             'model_fields.test_floatfield.TestFloatField.test_float_validates_object',
-        },
-        'Unused DatabaseIntrospection.get_key_columns() not implemented.': {
-            'introspection.tests.IntrospectionTests.test_get_key_columns',
         },
         'Unused DatabaseIntrospection.get_sequences() not implemented.': {
             'introspection.tests.IntrospectionTests.test_sequence_list',
@@ -230,12 +237,15 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             'migrations.test_operations.OperationTests.test_alter_field_reloads_state_on_fk_with_to_field_target_changes',  # noqa
             'migrations.test_operations.OperationTests.test_rename_field_reloads_state_on_fk_target_changes',
             'schema.tests.SchemaTests.test_alter_field_type_and_db_collation',
+            'schema.tests.SchemaTests.test_alter_primary_key_the_same_name',
             'schema.tests.SchemaTests.test_alter_textual_field_keep_null_status',
             'schema.tests.SchemaTests.test_m2m_rename_field_in_target_model',
             'schema.tests.SchemaTests.test_rename',
         },
         'Snowflake: cannot change column type because they have incompatible collations.': {
+            'migrations.test_operations.OperationTests.test_alter_field_pk_fk_db_collation',
             'schema.tests.SchemaTests.test_alter_field_db_collation',
+            'schema.tests.SchemaTests.test_alter_primary_key_db_collation',
             'schema.tests.SchemaTests.test_ci_cs_db_collation',
         },
     }

--- a/django_snowflake/operations.py
+++ b/django_snowflake/operations.py
@@ -36,49 +36,49 @@ class DatabaseOperations(BaseDatabaseOperations):
             return 'POWER(%s)' % ','.join(sub_expressions)
         return super().combine_expression(connector, sub_expressions)
 
-    def _convert_field_to_tz(self, field_name, tzname):
+    def _convert_sql_to_tz(self, sql, params, tzname):
         if tzname and settings.USE_TZ:
-            field_name = "CONVERT_TIMEZONE('%s', TO_TIMESTAMP(%s))" % (
+            return f"CONVERT_TIMEZONE(%s, TO_TIMESTAMP({sql}))", (
                 tzname,
-                field_name,
+                *params,
             )
-        return field_name
+        return sql, params
 
-    def datetime_cast_date_sql(self, field_name, tzname):
-        field_name = self._convert_field_to_tz(field_name, tzname)
-        return '(%s)::date' % field_name
+    def datetime_cast_date_sql(self, sql, params, tzname):
+        sql, params = self._convert_sql_to_tz(sql, params, tzname)
+        return f'({sql})::date', params
 
-    def datetime_cast_time_sql(self, field_name, tzname):
-        field_name = self._convert_field_to_tz(field_name, tzname)
-        return '(%s)::time' % field_name
+    def datetime_cast_time_sql(self, sql, params, tzname):
+        sql, params = self._convert_sql_to_tz(sql, params, tzname)
+        return f'({sql})::time', params
 
-    def date_extract_sql(self, lookup_type, field_name):
+    def date_extract_sql(self, lookup_type, sql, params):
         # https://docs.snowflake.com/en/sql-reference/functions-date-time.html#label-supported-date-time-parts
         if lookup_type == 'week_day':
             # For consistency across backends, return Sunday=1, Saturday=7.
-            return "EXTRACT('dow', %s) + 1" % field_name
+            return f"EXTRACT('dow', {sql}) + 1", params
         elif lookup_type == 'iso_week_day':
-            return "EXTRACT('dow_iso', %s)" % field_name
+            return f"EXTRACT('dow_iso', {sql})", params
         elif lookup_type == 'iso_year':
-            return "EXTRACT('yearofweekiso', %s)" % field_name
+            return f"EXTRACT('yearofweekiso', {sql})", params
         else:
-            return "EXTRACT('%s', %s)" % (lookup_type, field_name)
+            return f"EXTRACT(%s, {sql})", (lookup_type, *params)
 
-    def datetime_extract_sql(self, lookup_type, field_name, tzname):
-        field_name = self._convert_field_to_tz(field_name, tzname)
-        return self.date_extract_sql(lookup_type, field_name)
+    def datetime_extract_sql(self, lookup_type, sql, params, tzname):
+        sql, params = self._convert_sql_to_tz(sql, params, tzname)
+        return self.date_extract_sql(lookup_type, sql, params)
 
-    def date_trunc_sql(self, lookup_type, field_name, tzname=None):
-        field_name = self._convert_field_to_tz(field_name, tzname)
-        return "DATE_TRUNC('%s', %s)" % (lookup_type, field_name)
+    def date_trunc_sql(self, lookup_type, sql, params, tzname=None):
+        sql, params = self._convert_sql_to_tz(sql, params, tzname)
+        return f"DATE_TRUNC(%s, {sql})", (lookup_type, *params)
 
-    def datetime_trunc_sql(self, lookup_type, field_name, tzname):
-        field_name = self._convert_field_to_tz(field_name, tzname)
-        return "DATE_TRUNC('%s', %s)" % (lookup_type, field_name)
+    def datetime_trunc_sql(self, lookup_type, sql, params, tzname):
+        sql, params = self._convert_sql_to_tz(sql, params, tzname)
+        return f"DATE_TRUNC(%s, {sql})", (lookup_type, *params)
 
-    def time_trunc_sql(self, lookup_type, field_name, tzname=None):
-        field_name = self._convert_field_to_tz(field_name, tzname)
-        return "DATE_TRUNC('%s', %s)::time" % (lookup_type, field_name)
+    def time_trunc_sql(self, lookup_type, sql, params, tzname=None):
+        sql, params = self._convert_sql_to_tz(sql, params, tzname)
+        return f"DATE_TRUNC(%s, {sql})::time", (lookup_type, *params)
 
     def format_for_duration_arithmetic(self, sql):
         return "INTERVAL '%s MICROSECONDS'" % sql

--- a/django_snowflake/schema.py
+++ b/django_snowflake/schema.py
@@ -35,6 +35,8 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         # It might not actually have a column behind it
         if definition is None:
             return
+        if col_type_suffix := field.db_type_suffix(connection=self.connection):
+            definition += f" {col_type_suffix}"
         if field.remote_field and field.db_constraint:
             # Add FK constraint inline.
             constraint_suffix = '_fk_%(to_table)s_%(to_column)s'
@@ -87,7 +89,7 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         # Check for fields that aren't actually columns (e.g. M2M)
         if sql is None:
             return None, None
-        collation = getattr(field, 'db_collation', None)
+        collation = db_params.get('collation')
         if collation:
             sql += self._collate_sql(collation)
         if not field.null and not exclude_not_null:

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ long_description_content_type = text/markdown
 classifiers =
     Development Status :: 3 - Alpha
     Framework :: Django
-    Framework :: Django :: 4.0
+    Framework :: Django :: 4.1
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
@@ -19,6 +19,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 project_urls =
     Source = https://github.com/cedar-team/django-snowflake
     Tracker = https://github.com/cedar-team/django-snowflake/issues


### PR DESCRIPTION
- Update signature of DatabaseOperations.date_extract_sql(), date_trunc_sql,
  et al. per https://github.com/django/django/commit/585ed2f6d7e02b64747770add0e2d3749980d73c.

- Update SchemaEditor.add_field() per
  https://github.com/django/django/commit/3848475eeb5ee8f7729440f50c04fd85cf8bea66.

- Remove DatabaseFeatures.has_case_insensitive_like as the base class now 
  defaults to False.

- Set DatabaseFeatures.allows_multiple_constraints_on_same_fields = False to
  skip tests from https://github.com/django/django/commit/ae7aecc93eed0710e74fd3f47e4fc76e5081c7d3
  that define multiple unique constraints on the same field as Snowflake
  prohibits this.

- Update SchemaEditor.column_sql() to get collation from db_parameters per
  https://github.com/django/django/commit/87da2833384b7acd99a778a78e07ea6640f54f35.