### PR TITLE
Remove test_duration_with_datetime_microseconds from expected failures

### DIFF
--- a/django_snowflake/features.py
+++ b/django_snowflake/features.py
@@ -70,9 +70,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         'expressions.tests.FTimeDeltaTests.test_duration_with_datetime',
         'expressions.tests.FTimeDeltaTests.test_durationfield_add',
         'expressions.tests.FTimeDeltaTests.test_durationfield_multiply_divide',
-        # Interval math off by one microsecond for years beyond ~2250:
-        # https://github.com/snowflakedb/snowflake-connector-python/issues/926
-        'expressions.tests.FTimeDeltaTests.test_duration_with_datetime_microseconds',
         # Interval math off by one hour due to crossing daylight saving time.
         'expressions.tests.FTimeDeltaTests.test_delta_update',
         # Altering Integer PK to AutoField not supported.

--- a/django_snowflake/features.py
+++ b/django_snowflake/features.py
@@ -175,11 +175,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             'queries.tests.Queries1Tests.test_ticket7096',
             'queries.tests.Queries1Tests.test_tickets_5324_6704',
             'queries.tests.Queries4Tests.test_ticket24525',
-            # invalid identifier '"subquery"."col1"'
-            'queries.tests.Queries6Tests.test_distinct_ordered_sliced_subquery_aggregation',
             'queries.tests.Queries6Tests.test_tickets_8921_9188',
-            # invalid identifier '"subquery"."dumbcategory_ptr_id"'
-            'queries.tests.SubqueryTests.test_distinct_ordered_sliced_subquery',
             'queries.tests.TestTicket24605.test_ticket_24605',
             'queries.tests.Ticket20788Tests.test_ticket_20788',
             'queries.tests.Ticket22429Tests.test_ticket_22429',


### PR DESCRIPTION
Fixed in snowflake-connector-python 2.7.7.