### PR TITLE
Allow user-provided application connection parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   column's declared precision, e.g. when the expression involves arithmetic on
   NUMBER columns.
 
+- Allow a user-provided ``DATABASES[...]['OPTIONS']['application']``. In older
+  versions, the default value (``"Django_SnowflakeConnector_X.Y.Z"``) cannot be
+  overridden.
+
 ## 6.0 - 2025-12-05
 
 Initial release for Django 6.0.x.

--- a/django_snowflake/base.py
+++ b/django_snowflake/base.py
@@ -100,7 +100,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             **settings_dict['OPTIONS'],
         }
         if os.environ.get('RUNNING_DJANGOS_TEST_SUITE') != 'true':
-            conn_params['application'] = 'Django_SnowflakeConnector_%s' % __version__
+            conn_params.setdefault('application', 'Django_SnowflakeConnector_%s' % __version__)
 
         if settings_dict['NAME']:
             conn_params['database'] = self.ops.quote_name(settings_dict['NAME'])


### PR DESCRIPTION
## Summary
- `get_connection_params()` previously always overwrote `application` with the
  hardcoded default `Django_SnowflakeConnector_<version>`, even if the
  developer had already set it via `DATABASES[...]['OPTIONS']['application']`.
- Since `OPTIONS` is already spread into `conn_params` earlier in the method,
  switch the hardcoded assignment to `conn_params.setdefault(...)` so a
  developer-supplied value in `OPTIONS` is respected, and the versioned
  default is only used when `application` isn't set.
